### PR TITLE
fix: wrong link, closes #1

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,4 +28,4 @@ Reference code is provided for the following systems:
 
 ## Dataset Download
 
-The FAD dataset is publicly available and can be downloaded from Zenodo [https://zenodo.org/record/6635521\#.Ysjq4nZBw2x](https://zenodo.org/record/6635521#.Ysjq4nZBw2x)
+The FAD dataset is publicly available and can be downloaded from Zenodo [https://zenodo.org/record/6641573\#.Y7rdvuzML9A](https://zenodo.org/record/6641573#.Y7rdvuzML9A)

--- a/README.md
+++ b/README.md
@@ -28,4 +28,4 @@ Reference code is provided for the following systems:
 
 ## Dataset Download
 
-The FAD dataset is publicly available and can be downloaded from Zenodo [https://zenodo.org/record/6635521#.Ysjq4nZBw2x](https://zenodo.org/record/6635521#.Ysjq4nZBw2x)
+The FAD dataset is publicly available and can be downloaded from Zenodo [https://zenodo.org/record/6635521\#.Ysjq4nZBw2x](https://zenodo.org/record/6635521#.Ysjq4nZBw2x)

--- a/README.md
+++ b/README.md
@@ -28,4 +28,4 @@ Reference code is provided for the following systems:
 
 ## Dataset Download
 
-The FAD dataset is publicly available and can be downloaded from Zenodo [https://zenodo.org/record/6635521\\#.Ysjq4nZBw2x](https://zenodo.org/record/6635521%5C%5C#.Ysjq4nZBw2x)
+The FAD dataset is publicly available and can be downloaded from Zenodo [https://zenodo.org/record/6635521#.Ysjq4nZBw2x](https://zenodo.org/record/6635521#.Ysjq4nZBw2x)


### PR DESCRIPTION
the link bring me to a wrong zenodo page indeed I get `page not found`
I got the working link from the arxiv article

closes https://github.com/ADDchallenge/FAD/issues/1